### PR TITLE
feat: chart tooltip

### DIFF
--- a/gui/src/dashboard_page/Ecu.jsx
+++ b/gui/src/dashboard_page/Ecu.jsx
@@ -106,7 +106,7 @@ export function Ecu({toggleKey, keydown}) {
                             <RocketSwitch
                                 name="COPV Vent"
                                 className="switches"
-                                expected_value={solenoids["CopvVent"]["expected"]}
+                                expected_value={solenoids["CopvVent"]?.["expected"]}
                                 feedback_value={solenoids["CopvVent"]["current"]}
                                 onClick={(event) => handleToggleState("ecu", "CopvVent", event)}
                                 enabled={keydown === toggleKey && !isAborted}
@@ -114,7 +114,7 @@ export function Ecu({toggleKey, keydown}) {
                             <RocketSwitch
                                 name="Vent"
                                 className="switches"
-                                expected_value={solenoids["Vent"]["expected"]}
+                                expected_value={solenoids["Vent"]?.["expected"]}
                                 feedback_value={solenoids["Vent"]["current"]}
                                 onClick={(event) => handleToggleState("ecu", "Vent", event)}
                                 enabled={keydown === toggleKey && !isAborted}
@@ -125,7 +125,7 @@ export function Ecu({toggleKey, keydown}) {
                             <RocketSwitch
                                 name="PV1"
                                 className="switches"
-                                expected_value={solenoids["Pv1"]["expected"]}
+                                expected_value={solenoids["Pv1"]?.["expected"]}
                                 feedback_value={solenoids["Pv1"]["current"]}
                                 onClick={(event) => handleToggleState("ecu", "Pv1", event)}
                                 enabled={keydown === toggleKey && !isAborted}
@@ -133,7 +133,7 @@ export function Ecu({toggleKey, keydown}) {
                             <RocketSwitch
                                 name="PV2"
                                 className="switches"
-                                expected_value={solenoids["Pv2"]["expected"]}
+                                expected_value={solenoids["Pv2"]?.["expected"]}
                                 feedback_value={solenoids["Pv2"]["current"]}
                                 onClick={(event) => handleToggleState("ecu", "Pv2", event)}
                                 enabled={keydown === toggleKey && !isAborted}

--- a/gui/src/dashboard_page/pressure_graph/PressureChart.jsx
+++ b/gui/src/dashboard_page/pressure_graph/PressureChart.jsx
@@ -10,6 +10,7 @@ import {
 } from "recharts";
 import {useState} from "react";
 import styles from "../DashboardPage.module.css";
+
 export function PressureChart({data}) {
     const [dataKey, setDatakey] = useState();
 
@@ -62,7 +63,20 @@ export function PressureChart({data}) {
                         }
                     />
                     <YAxis domain={["auto"]} />
-                    <Tooltip />
+                    <Tooltip
+                        contentStyle={{fontSize: 24}}
+                        labelStyle={{color: "black", paddingLeft: 0}}
+                        labelFormatter={(label) => (
+                            <p
+                                style={{
+                                    padding: 0,
+                                    margin: 0
+                                }}
+                            >
+                                Time: {label}
+                            </p>
+                        )}
+                    />
                     <Legend />
                     {dataKey === undefined || dataKey === "Copv" ? (
                         <Line

--- a/gui/src/dashboard_page/tc_graph/TcChart.jsx
+++ b/gui/src/dashboard_page/tc_graph/TcChart.jsx
@@ -8,7 +8,6 @@ import {
     Legend,
     ResponsiveContainer
 } from "recharts";
-import {useState} from "react";
 
 export function TcChart({data}) {
     return (
@@ -27,7 +26,20 @@ export function TcChart({data}) {
                         }
                     />
                     <YAxis domain={["auto"]} />
-                    <Tooltip />
+                    <Tooltip
+                        contentStyle={{fontSize: 24}}
+                        labelStyle={{color: "black", paddingLeft: 0}}
+                        labelFormatter={(label) => (
+                            <p
+                                style={{
+                                    padding: 0,
+                                    margin: 0
+                                }}
+                            >
+                                Time: {label}
+                            </p>
+                        )}
+                    />
                     <Legend />
 
                     <Line


### PR DESCRIPTION
## Summary
1. Updates chart tooltips so they read the time correctly

<img width="852" alt="Screenshot 2024-11-05 at 3 24 03 PM" src="https://github.com/user-attachments/assets/5cb4fa72-66e7-414e-83c7-bfb3e7bf0504">
