### PR TITLE
feat: fixing load cell

### DIFF
--- a/gui/src/dashboard_page/DashboardPage.jsx
+++ b/gui/src/dashboard_page/DashboardPage.jsx
@@ -90,11 +90,11 @@ export function DashboardPage() {
             />
             <div
                 className={styles.graphBox}
-                style={{overflowY:"auto", height: "95vh"}}
+                style={{overflowY: "auto", height: "95vh"}}
             >
                 <TcChartContainer />
                 <PressureChartContainer />
-                {/* <LoadCellChartContainer /> */ /**NEED TO STOP IT FROM INFINITELY SAVING DATA */} 
+                <LoadCellChartContainer />
             </div>
             <Ecu
                 toggleKey={TOGGLE_KEY}

--- a/gui/src/dashboard_page/load_cell_graph/LoadCellChartContainer.jsx
+++ b/gui/src/dashboard_page/load_cell_graph/LoadCellChartContainer.jsx
@@ -7,13 +7,13 @@ export function LoadCellChartContainer() {
     const {misc} = useContext(RocketState);
 
     const miscRef = useRef(misc);
-    const intervalRef = useRef(null);
 
     const [data, setData] = useState([]);
 
     useEffect(() => {
         const startTime = Date.now();
-        intervalRef.current = setInterval(() => {
+
+        const intervalId = setInterval(() => {
             const elapsedSeconds = Math.max(0, Math.floor((Date.now() - startTime) / 1000));
 
             setData((prevData) => {
@@ -21,7 +21,7 @@ export function LoadCellChartContainer() {
                     ...prevData,
                     {
                         time: elapsedSeconds,
-                        force: miscRef.current.force
+                        force: miscRef.current.total_force
                     }
                 ];
 
@@ -30,11 +30,15 @@ export function LoadCellChartContainer() {
                 );
             });
         }, 1000);
-    }, [misc]);
+
+        return () => clearInterval(intervalId);
+    }, []);
 
     useEffect(() => {
         miscRef.current = misc;
     }, [misc]);
+
+    console.log(data);
 
     return (
         <div

--- a/gui/src/dashboard_page/pressure_graph/PressureChartContainer.jsx
+++ b/gui/src/dashboard_page/pressure_graph/PressureChartContainer.jsx
@@ -7,13 +7,13 @@ export function PressureChartContainer() {
     const {pts} = useContext(RocketState);
 
     const ptsRef = useRef(pts);
-    const intervalRef = useRef(null);
 
     const [data, setData] = useState([]);
 
     useEffect(() => {
         const startTime = Date.now();
-        intervalRef.current = setInterval(() => {
+
+        const intervalId = setInterval(() => {
             const elapsedSeconds = Math.max(0, Math.floor((Date.now() - startTime) / 1000));
 
             setData((prevData) => {
@@ -32,6 +32,8 @@ export function PressureChartContainer() {
                 );
             });
         }, 1000);
+
+        return () => clearInterval(intervalId);
     }, []);
 
     useEffect(() => {

--- a/gui/src/dashboard_page/tc_graph/TcChartContainer.jsx
+++ b/gui/src/dashboard_page/tc_graph/TcChartContainer.jsx
@@ -8,13 +8,13 @@ export function TcChartContainer() {
     const {tcs} = useContext(RocketState);
 
     const tcsRef = useRef(tcs);
-    const intervalRef = useRef(null);
 
     const [data, setData] = useState([]);
 
     useEffect(() => {
         const startTime = Date.now();
-        intervalRef.current = setInterval(() => {
+
+        const intervalId = setInterval(() => {
             const elapsedSeconds = Math.max(0, Math.floor((Date.now() - startTime) / 1000));
 
             setData((prevData) => {
@@ -31,6 +31,8 @@ export function TcChartContainer() {
                 );
             });
         }, 1000);
+
+        return () => clearInterval(intervalId);
     }, []);
 
     useEffect(() => {

--- a/webservice/server.py
+++ b/webservice/server.py
@@ -1,4 +1,5 @@
 import logging
+import random
 import socket
 import time
 import json
@@ -91,7 +92,7 @@ load_cell_connection_lock = Lock()
 
 load_cell_state = {
     "time_recv": 0,
-    "force": 0,
+    "total_force": 0,
 }
 
 app = Flask(__name__)


### PR DESCRIPTION
Corrects some React footguns to reduce rerenders. Specifically, we now clear the `interval` we set for fetching data every 250ms when we rerender, preventing a cascading effect of many many fetches (and rerenders, and fetches, etc)

